### PR TITLE
refactor(BUX-272): Change the order of elements in decoded CMP

### DIFF
--- a/p2p_beef_tx.go
+++ b/p2p_beef_tx.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+
 	"github.com/libsv/go-bc"
 	"github.com/libsv/go-bt/v2"
 )
@@ -48,7 +49,7 @@ func (dBeef *DecodedBEEF) GetMerkleRoots() ([]string, error) {
 }
 
 func calculateMerkleRoot(baseTx string, offset uint64, cmp []map[string]uint64) (string, error) {
-	for i := len(cmp) - 1; i >= 0; i-- {
+	for i := 0; i < len(cmp); i++ {
 		var leftNode, rightNode string
 		newOffset := offset - 1
 		if offset%2 == 0 {
@@ -166,7 +167,8 @@ func NewCMPFromStream(hexBytes []byte) (CompoundMerklePath, int, error) {
 			return nil, 0, err
 		}
 
-		cmp = append(cmp, pathMap)
+		cmp = append(CompoundMerklePath{pathMap}, cmp...)
+
 		hexBytes = hexBytes[bytesUsed:]
 
 		currentHeight--

--- a/p2p_beef_tx_test.go
+++ b/p2p_beef_tx_test.go
@@ -3,11 +3,11 @@ package paymail
 import (
 	"context"
 	"errors"
-	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/libsv/go-bt/v2"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Mock implementation of a service provider
@@ -33,9 +33,16 @@ func TestDecodeBEEF_DecodeBEEF_HappyPaths(t *testing.T) {
 			expectedDecodedBEEF: &DecodedBEEF{
 				CMPSlice: CMPSlice{
 					{
+						{
+							"8c00bb9360e93fb822c84b2e579fa4ce75c8378ae87f67730a49552f73c56ee8": 0x0,
+							"da256f78ae0ad74bbf539662cdb9122aa02ba9a9d883f1d52468d96290515adb": 0x1,
+							"b4c8d919190a090e77b73ffcd52b85babaaeeb62da000473102aca7f070facef": 0x2,
+							"e5b331f4961d764373f3a4e2751954e75489fb17902aad583eedbb41dc165a3b": 0x3,
+						},
+						{
+							"3470d882cf556a4b943639eba15dc795dffdbebdc98b9a98e3637fda96e3811e": 0x0, "c58e40f22b9e9fcd05a09689a9b19e6e62dbfd3335c5253d09a7a7cd755d9a3c": 0x1,
+						},
 						{"cd73c0c6bb645581816fa960fd2f1636062fcbf23cb57981074ab8d708a76e3b": 0x1},
-						{"3470d882cf556a4b943639eba15dc795dffdbebdc98b9a98e3637fda96e3811e": 0x0, "c58e40f22b9e9fcd05a09689a9b19e6e62dbfd3335c5253d09a7a7cd755d9a3c": 0x1},
-						{"8c00bb9360e93fb822c84b2e579fa4ce75c8378ae87f67730a49552f73c56ee8": 0x0, "da256f78ae0ad74bbf539662cdb9122aa02ba9a9d883f1d52468d96290515adb": 0x1, "b4c8d919190a090e77b73ffcd52b85babaaeeb62da000473102aca7f070facef": 0x2, "e5b331f4961d764373f3a4e2751954e75489fb17902aad583eedbb41dc165a3b": 0x3},
 					},
 				},
 				InputsTxData: []TxData{
@@ -87,14 +94,30 @@ func TestDecodeBEEF_DecodeBEEF_HappyPaths(t *testing.T) {
 			expectedDecodedBEEF: &DecodedBEEF{
 				CMPSlice: CMPSlice{
 					{
+						{
+							"8c00bb9360e93fb822c84b2e579fa4ce75c8378ae87f67730a49552f73c56ee8": 0x0,
+							"da256f78ae0ad74bbf539662cdb9122aa02ba9a9d883f1d52468d96290515adb": 0x1,
+							"b4c8d919190a090e77b73ffcd52b85babaaeeb62da000473102aca7f070facef": 0x2,
+							"e5b331f4961d764373f3a4e2751954e75489fb17902aad583eedbb41dc165a3b": 0x3,
+						},
+						{
+							"3470d882cf556a4b943639eba15dc795dffdbebdc98b9a98e3637fda96e3811e": 0x0,
+							"c58e40f22b9e9fcd05a09689a9b19e6e62dbfd3335c5253d09a7a7cd755d9a3c": 0x1,
+						},
 						{"cd73c0c6bb645581816fa960fd2f1636062fcbf23cb57981074ab8d708a76e3b": 0x1},
-						{"3470d882cf556a4b943639eba15dc795dffdbebdc98b9a98e3637fda96e3811e": 0x0, "c58e40f22b9e9fcd05a09689a9b19e6e62dbfd3335c5253d09a7a7cd755d9a3c": 0x1},
-						{"8c00bb9360e93fb822c84b2e579fa4ce75c8378ae87f67730a49552f73c56ee8": 0x0, "da256f78ae0ad74bbf539662cdb9122aa02ba9a9d883f1d52468d96290515adb": 0x1, "b4c8d919190a090e77b73ffcd52b85babaaeeb62da000473102aca7f070facef": 0x2, "e5b331f4961d764373f3a4e2751954e75489fb17902aad583eedbb41dc165a3b": 0x3},
 					},
 					{
+						{
+							"8c00bb9360e93fb822c84b2e579fa4ce75c8378ae87f67730a49552f73c56ee8": 0x0,
+							"da256f78ae0ad74bbf539662cdb9122aa02ba9a9d883f1d52468d96290515adb": 0x1,
+							"b4c8d919190a090e77b73ffcd52b85babaaeeb62da000473102aca7f070facef": 0x2,
+							"e5b331f4961d764373f3a4e2751954e75489fb17902aad583eedbb41dc165a3b": 0x3,
+						},
+						{
+							"3470d882cf556a4b943639eba15dc795dffdbebdc98b9a98e3637fda96e3811e": 0x0,
+							"c58e40f22b9e9fcd05a09689a9b19e6e62dbfd3335c5253d09a7a7cd755d9a3c": 0x1,
+						},
 						{"cd73c0c6bb645581816fa960fd2f1636062fcbf23cb57981074ab8d708a76e3b": 0x1},
-						{"3470d882cf556a4b943639eba15dc795dffdbebdc98b9a98e3637fda96e3811e": 0x0, "c58e40f22b9e9fcd05a09689a9b19e6e62dbfd3335c5253d09a7a7cd755d9a3c": 0x1},
-						{"8c00bb9360e93fb822c84b2e579fa4ce75c8378ae87f67730a49552f73c56ee8": 0x0, "da256f78ae0ad74bbf539662cdb9122aa02ba9a9d883f1d52468d96290515adb": 0x1, "b4c8d919190a090e77b73ffcd52b85babaaeeb62da000473102aca7f070facef": 0x2, "e5b331f4961d764373f3a4e2751954e75489fb17902aad583eedbb41dc165a3b": 0x3},
 					},
 				},
 				InputsTxData: []TxData{
@@ -171,7 +194,11 @@ func TestDecodeBEEF_DecodeBEEF_HappyPaths(t *testing.T) {
 			assert.Equal(t, tc.expectedError, err, "expected error %v, but got %v", tc.expectedError, err)
 
 			assert.Equal(t, len(tc.expectedDecodedBEEF.InputsTxData), len(decodedBEEF.InputsTxData), "expected %v inputs, but got %v", len(tc.expectedDecodedBEEF.InputsTxData), len(decodedBEEF.InputsTxData))
+
 			assert.Equal(t, len(tc.expectedDecodedBEEF.CMPSlice), len(decodedBEEF.CMPSlice), "expected %v CMPs, but got %v", len(tc.expectedDecodedBEEF.CMPSlice), len(decodedBEEF.CMPSlice))
+
+			assert.Equal(t, tc.expectedDecodedBEEF.CMPSlice, decodedBEEF.CMPSlice, "expected decoded CMP to be %v, but got %v", tc.expectedDecodedBEEF.CMPSlice, decodedBEEF.CMPSlice)
+
 			assert.NotNil(t, decodedBEEF.ProcessedTxData.Transaction, "expected original transaction to be not nil")
 
 			assert.Equal(t, tc.expectedDecodedBEEF.InputsTxData[0].PathIndex, decodedBEEF.InputsTxData[0].PathIndex, "expected path index for the oldest input to be %v, but got %v", tc.expectedDecodedBEEF.InputsTxData[0].PathIndex, decodedBEEF.InputsTxData[0].PathIndex)


### PR DESCRIPTION
Change the order of elements in the decoded CMP to reflect the BRC (https://bsv.brc.dev/transactions/0061)

# Pull Request Checklist

- [x] 📖 I created my PR using provided  : [CODE_STANDARDS](https://github.com/bitcoin-sv/go-paymail/blob/main/.github/CODE_STANDARDS.md)
- [x] 📖 I have read the short Code of Conduct: [CODE_OF_CONDUCT](https://github.com/bitcoin-sv/go-paymail/blob/main/.github/CODE_OF_CONDUCT.md)
- [x] 🏠 I tested my changes locally.
- [x] ✅ I have provided tests for my changes.
- [x] 📝 I have used conventional commits.
- [ ] 📗 I have updated any related documentation.
- [x] 💾 PR was issued based on the Github or Jira issue.
