### PR TITLE
fix: Update nLocktime nSequence handling

### DIFF
--- a/spv/spv.go
+++ b/spv/spv.go
@@ -60,13 +60,12 @@ func ExecuteSimplifiedPaymentVerification(ctx context.Context, dBeef *beef.Decod
 
 func validateLockTime(tx *bt.Tx) error {
 	if tx.LockTime == 0 {
-		for _, input := range tx.Inputs {
-			if input.SequenceNumber != 0xffffffff {
-				return errors.New("unexpected transaction with nSequence")
-			}
+		return nil
+	}
+	for _, input := range tx.Inputs {
+		if input.SequenceNumber != 0xffffffff {
+			return errors.New("nLocktime is set and nSequence is not max, therefore this could be a non-final tx which is not currently supported.")
 		}
-	} else {
-		return errors.New("unexpected transaction with nLockTime")
 	}
 	return nil
 }


### PR DESCRIPTION
# Pull Request Checklist

- [x] 📖 I created my PR using provided  : [CODE_STANDARDS](https://github.com/bitcoin-sv/go-paymail/blob/main/.github/CODE_STANDARDS.md)
- [x] 📖 I have read the short Code of Conduct: [CODE_OF_CONDUCT](https://github.com/bitcoin-sv/go-paymail/blob/main/.github/CODE_OF_CONDUCT.md)
- [ ] 🏠 I tested my changes locally.
- [ ] ✅ I have provided tests for my changes.
- [ ] 📝 I have used conventional commits.
- [ ] 📗 I have updated any related documentation.
- [ ] 💾 PR was issued based on the Github or Jira issue.

## Issue Details

nLocktime handling should ignore 0, and only check nSequence of inputs in the case that nLocktime is non 0 to ensure the tx is indeed final.