### PR TITLE
[Sync] Update project files from source repository (55c7f74)

### DIFF
--- a/.github/env/10-mage-x.env
+++ b/.github/env/10-mage-x.env
@@ -36,7 +36,7 @@
 # ================================================================================================
 
 # MAGE-X version
-MAGE_X_VERSION=v1.25.0
+MAGE_X_VERSION=v1.25.1
 
 # For mage-x development, set to 'true' to use local version instead of downloading from releases
 MAGE_X_USE_LOCAL=false

--- a/.github/workflows/auto-merge-on-approval.yml
+++ b/.github/workflows/auto-merge-on-approval.yml
@@ -286,7 +286,9 @@ jobs:
             // Get latest review per user
             const latestReviews = {};
             reviews.forEach(review => {
-              const userId = review.user.id;
+              // review.user is null for deleted accounts - fall back to a unique
+              // key so the review still counts instead of throwing.
+              const userId = review.user?.id ?? `deleted-user:${review.id}`;
               if (!latestReviews[userId] || review.submitted_at > latestReviews[userId].submitted_at) {
                 latestReviews[userId] = review;
               }

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -49,7 +49,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           languages: ${{ matrix.language }}
           # If you wish to specify custom queries, you can do so here or in a config file.
@@ -60,7 +60,7 @@ jobs:
       # Autobuild attempts to build any compiled languages (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/autobuild@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -70,4 +70,4 @@ jobs:
       #    uses a compiled language
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -57,7 +57,7 @@ concurrency:
 # Note: Configuration variables are loaded from modular .github/env/ files
 
 jobs:
-  # -------------------------------------------------g---------------------------------
+  # ----------------------------------------------------------------------------------
   # Dependabot processing (single consolidated job)
   #
   # Workflow phases (each preserved as a step):
@@ -787,7 +787,9 @@ jobs:
             });
             const latestReviews = {};
             reviews.forEach(review => {
-              const userId = review.user.id;
+              // review.user is null for deleted accounts - fall back to a unique
+              // key so the review still counts instead of throwing.
+              const userId = review.user?.id ?? `deleted-user:${review.id}`;
               if (!latestReviews[userId] || review.submitted_at > latestReviews[userId].submitted_at) {
                 latestReviews[userId] = review;
               }

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -77,6 +77,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable the upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## What Changed

* Updated MAGE_X_VERSION from `v1.25.0` to `v1.25.1` in `.github/env/10-mage-x.env`
* Fixed a typo in the comment separator line in `.github/workflows/dependabot-auto-merge.yml` (removed extra 'g' character)
* Added null-safety handling for deleted user accounts in the review processing logic, using optional chaining (`review.user?.id`) and falling back to `deleted-user:${review.id}` when `review.user` is null
* Updated CodeQL action references from `e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81` (v4.37.3) to `f205ea1c3313d32999d8d6a48b4f6530d4437b38` (v4.37.4) in both `init` and `autobuild` steps across multiple workflow files

## Why It Was Necessary

* Prevents workflow failures when processing pull request reviews from deleted GitHub accounts, which previously would throw errors when attempting to access `review.user.id`
* Updates MAGE-X to the latest patch version for bug fixes or improvements
* Keeps CodeQL security scanning tools up to date with the latest version containing potential bug fixes or security improvements

## Testing Performed

* The null-safety fix should be validated by testing the dependabot workflow against a PR with reviews from deleted accounts
* Verify that MAGE-X v1.25.1 loads correctly in the CI environment
* Confirm that CodeQL analysis workflows complete successfully with the updated action versions

## Impact / Risk

* **Low Risk**: The null-safety fix is defensive programming that handles an edge case without changing behavior for normal cases
* **No Breaking Changes**: All updates are backward compatible (patch version bump for MAGE-X, minor version bump for CodeQL)
* **Improved Stability**: Prevents crashes in the dependabot auto-merge workflow when encountering reviews from deleted users

<!-- go-broadcast-metadata
group:
  id: bsv-blockchain-forks
  name: bsv-blockchain-forks
diff_info:
  staged_repo_available: true
  changed_files_count: 5
  files_with_original_content: 5
  files_without_original_content: 0
sync_metadata:
  source_repo: mrz1836/go-broadcast
  source_commit: 55c7f745fe5ca530414b439da64f611340618a4f
  target_repo: bsv-blockchain/go-paymail
  sync_commit: ddebee515a50280285ba9cf9e8d3837417088e7e
  sync_time: 2026-08-03T15:56:46-04:00
ai_generated:
  commit_message: true
  pr_body: true
directories:
  - src: .github/ISSUE_TEMPLATE
    dest: .github/ISSUE_TEMPLATE
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 3
    files_excluded: 0
    processing_time_ms: 334
  - src: .github/actions
    dest: .github/actions
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 19
    files_excluded: 0
    processing_time_ms: 1274
  - src: .github/docs
    dest: .github/docs
    excluded: ["workflows-private.md"]
    files_synced: 0
    files_examined: 2
    files_excluded: 1
    processing_time_ms: 398
  - src: .github/env
    dest: .github/env
    excluded: ["20-guardian.env", "90-project.env", "99-local.env"]
    files_synced: 1
    files_examined: 9
    files_excluded: 2
    processing_time_ms: 1323
  - src: .github/scripts
    dest: .github/scripts
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 1
    files_excluded: 0
    processing_time_ms: 431
  - src: .github/tech-conventions
    dest: .github/tech-conventions
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 14
    files_excluded: 0
    processing_time_ms: 1028
  - src: .github/workflows
    dest: .github/workflows
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 4
    files_examined: 20
    files_excluded: 0
    processing_time_ms: 884
  - src: .vscode
    dest: .vscode
    excluded: ["*.out", "*.test", "*.exe", "**/.DS_Store", "**/tmp/*", "**/.git"]
    files_synced: 0
    files_examined: 4
    files_excluded: 0
    processing_time_ms: 381
performance:
  total_files: 102
-->
